### PR TITLE
Update settings of favonia/cloudflare-ddns

### DIFF
--- a/dots/scripts/containers/active/ddns/ddns
+++ b/dots/scripts/containers/active/ddns/ddns
@@ -29,9 +29,6 @@ _prep_mounts() {
 _prep_caps() {
   _caps=""
 
-  _caps="${_caps} --cap-add SETUID"
-  _caps="${_caps} --cap-add SETGID"
-
   readonly _caps
   return 0
 }
@@ -59,8 +56,8 @@ _check_user() {
     fi
   fi
 
-  # Expects to be root (since the cert file is owned by root)
-  _userns=""
+  # No need to run as root
+  _userns="--user 1000:1000"
 
   readonly _userns
 }
@@ -118,8 +115,6 @@ _containerize() {
   _runas ${_cmd} run --rm -i -t \
     --name "${_name}" --hostname "${_name}" \
     -e PROXIED=false \
-    -e PUID=1000 \
-    -e PGID=1000 \
     ${_network} \
     ${_dd} \
     ${_sec} \


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0 released on 16 July](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer and more reliable, but it made the old Docker template (which grants `SETUID` and `SETGID`) potentially less secure. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in my DDNS updater.

PS: The new template is compatible with older versions as well, in case you do not want to upgrade the updater.
PPS: I did not test the new script, but if the old script works, the option `--user 1000:1000` should also work.